### PR TITLE
Suggestion: set default of maxP to NULL

### DIFF
--- a/R/fastman.R
+++ b/R/fastman.R
@@ -1,4 +1,4 @@
-fastman <- function(m, chr = "CHR", bp = "BP", p = "P", snp, chrlabs, speedup=TRUE, logp = TRUE, col="matlab", maxP=14, sortchr=TRUE, bybp=FALSE, chrsubset, bprange,
+fastman <- function(m, chr = "CHR", bp = "BP", p = "P", snp, chrlabs, speedup=TRUE, logp = TRUE, col="matlab", maxP=NULL, sortchr=TRUE, bybp=FALSE, chrsubset, bprange,
                            highlight, annotateHighlight=FALSE, annotatePval, colAbovePval=FALSE, col2="greys", annotateTop=TRUE, annotationWinMb, annotateN, annotationCol, annotationAngle=45, 
                            baseline=NULL, suggestiveline, genomewideline, cex=0.4, cex.text=0.4, cex.axis=0.6, xlab, ylab, xlim, ylim, ...) {
 


### PR DESCRIPTION
Current biobank and meta-GWAS are well-powered enough that almost all will contain a P-value smaller than 1e-14, so there isn't a single value that is sensible default for truncating the Y axis. This PR sets `maxP=NULL` as the default.